### PR TITLE
Remove unnecessary prefixes

### DIFF
--- a/src/OpenAI/Servant/V1/Batches.hs
+++ b/src/OpenAI/Servant/V1/Batches.hs
@@ -48,10 +48,10 @@ data Counts = Counts
 data Batch = Batch
     { id :: Text
     , object :: Text
-    , batch_endpoint :: Text
+    , endpoint :: Text
     , errors :: Maybe (ListOf Error)
-    , batch_input_file_id :: Text
-    , batch_completion_window :: Text
+    , input_file_id :: Text
+    , completion_window :: Text
     , status :: Status
     , output_file_id :: Maybe Text
     , error_file_id :: Maybe Text
@@ -65,12 +65,11 @@ data Batch = Batch
     , cancelling_at :: Maybe POSIXTime
     , cancelled_at :: Maybe POSIXTime
     , request_counts :: Maybe Counts
-    , batch_metadata :: Maybe (Map Text Text)
+    , metadata :: Maybe (Map Text Text)
     } deriving stock (Generic, Show)
 
 instance FromJSON Batch where
     parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "batch_" }
 
 -- | API
 type API =

--- a/src/OpenAI/Servant/V1/Chat/Completions.hs
+++ b/src/OpenAI/Servant/V1/Chat/Completions.hs
@@ -35,38 +35,19 @@ import Prelude hiding (id)
 
 -- | Data about a previous audio response from the model.
 -- [Learn more](https://platform.openai.com/docs/guides/audio)
-data AudioData = AudioData{ audio_id :: Text }
+data AudioData = AudioData{ id :: Text }
     deriving stock (Generic, Show)
-
-audioDataOptions :: Options
-audioDataOptions = aesonOptions{ fieldLabelModifier = stripPrefix "audio_" }
-
-instance FromJSON AudioData where
-    parseJSON = genericParseJSON audioDataOptions
-
-instance ToJSON AudioData where
-    toJSON = genericToJSON audioDataOptions
+    deriving anyclass (FromJSON, ToJSON)
 
 -- | A called function
-data CalledFunction = CalledFunction
-    { called_name :: Text
-    , called_arguments :: Text
-    } deriving stock (Generic, Show)
-
-calledFunctionOptions :: Options
-calledFunctionOptions = aesonOptions
-    { fieldLabelModifier = stripPrefix "called_" }
-
-instance FromJSON CalledFunction where
-    parseJSON = genericParseJSON calledFunctionOptions
-
-instance ToJSON CalledFunction where
-    toJSON = genericToJSON calledFunctionOptions
+data CalledFunction = CalledFunction{ name :: Text, arguments :: Text }
+    deriving stock (Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
 
 -- | Tools called by the model
 data ToolCall = ToolCall_Function
-    { called_id :: Text
-    , called_function :: CalledFunction
+    { id :: Text
+    , function :: CalledFunction
     } deriving stock (Generic, Show)
 
 toolCallOptions :: Options
@@ -77,8 +58,6 @@ toolCallOptions = aesonOptions
     , tagSingleConstructors = True
 
     , constructorTagModifier = stripPrefix "ToolCall_"
-
-    , fieldLabelModifier = stripPrefix "called_"
     }
 
 instance ToJSON ToolCall where
@@ -138,7 +117,7 @@ instance ToJSON Modality where
 -- which can greatly improve response times when large parts of the model
 -- response are known ahead of time. This is most common when you are
 -- regenerating a file with only minor changes to most of the content
-data Prediction = Content{ prediction_content :: Text }
+data Prediction = Content{ content :: Text }
     deriving stock (Generic, Show)
 
 instance ToJSON Prediction where
@@ -147,8 +126,6 @@ instance ToJSON Prediction where
             TaggedObject{ tagFieldName = "type", contentsFieldName = "" }
 
         , tagSingleConstructors = True
-
-        , fieldLabelModifier = stripPrefix "prediction_"
         }
 
 -- | The voice the model uses to respond
@@ -177,15 +154,12 @@ data AudioParameters = AudioParameters
 -- schema. Learn more in the
 -- [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) guide
 data JSONSchema = JSONSchema
-    { schema_description :: Maybe Text
-    , schema_name :: Text
+    { description :: Maybe Text
+    , name :: Text
     , schema :: Maybe Value
-    , schema_strict :: Maybe Bool
+    , strict :: Maybe Bool
     } deriving stock (Generic, Show)
-
-instance ToJSON JSONSchema where
-    toJSON = genericToJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "schema_" }
+      deriving anyclass (ToJSON)
 
 -- | An object specifying the format that the model must output
 data ResponseFormat
@@ -205,34 +179,27 @@ instance ToJSON ResponseFormat where
         }
 
 -- | Specifies the latency tier to use for processing the request
-data ServiceTier = ServiceTier_Auto | ServiceTier_Default
+data ServiceTier = Auto | Default
     deriving stock (Generic, Show)
 
-serviceTierOptions :: Options
-serviceTierOptions = aesonOptions
-    { constructorTagModifier = stripPrefix "ServiceTier_" }
-
 instance FromJSON ServiceTier where
-    parseJSON = genericParseJSON serviceTierOptions
+    parseJSON = genericParseJSON aesonOptions
 
 instance ToJSON ServiceTier where
-    toJSON = genericToJSON serviceTierOptions
+    toJSON = genericToJSON aesonOptions
 
 -- | A callable function
 data CallableFunction = CallableFunction
-    { callable_description :: Maybe Text
-    , callable_name :: Text
+    { description :: Maybe Text
+    , name :: Text
     , parameters :: Maybe Value
     , strict :: Maybe Bool
     } deriving stock (Generic, Show)
-
-instance ToJSON CallableFunction where
-    toJSON = genericToJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "callable_" }
+      deriving anyclass (ToJSON)
 
 -- | Tools callable by the model
 data Tool = Tool_Function
-    { callable_function :: CallableFunction
+    { function :: CallableFunction
     } deriving stock (Generic, Show)
 
 instance ToJSON Tool where
@@ -243,8 +210,6 @@ instance ToJSON Tool where
         , tagSingleConstructors = True
 
         , constructorTagModifier = stripPrefix "Tool_"
-
-        , fieldLabelModifier = stripPrefix "callable_"
         }
 
 -- | Controls which (if any) tool is called by the model
@@ -308,57 +273,41 @@ data Token = Token
     { token :: Text
     , logprob :: Double
     , bytes :: Maybe (Vector Word8)
-    , token_top_logprobs :: Maybe (Vector Token)
+    , top_logprobs :: Maybe (Vector Token)
     } deriving stock (Generic, Show)
-
-instance FromJSON Token where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "token_" }
+      deriving anyclass (FromJSON)
 
 -- | Log probability information for the choice
 data LogProbs = LogProbs
-    { logProbs_content :: Maybe (Vector Token)
-    , logProbs_refusal :: Maybe (Vector Token)
+    { content :: Maybe (Vector Token)
+    , refusal :: Maybe (Vector Token)
     } deriving stock (Generic, Show)
-
-instance FromJSON LogProbs where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "logProbs_"
-        }
+      deriving anyclass (FromJSON)
 
 -- | A chat completion choice
 data Choice = Choice
     { finish_reason :: Text
     , index :: Natural
     , message :: Message
-    , choice_logprobs :: Maybe LogProbs
+    , logprobs :: Maybe LogProbs
     } deriving stock (Generic, Show)
-
-instance FromJSON Choice where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "choice_" }
+      deriving anyclass (FromJSON)
 
 -- | Breakdown of tokens used in a completion
 data CompletionTokensDetails = CompletionTokensDetails
     { accepted_prediction_tokens :: Natural
-    , completion_audio_tokens :: Natural
+    , audio_tokens :: Natural
     , reasoning_tokens :: Natural
     , rejected_prediction_tokens :: Natural
     } deriving stock (Generic, Show)
-
-instance FromJSON CompletionTokensDetails where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "completion_" }
+      deriving anyclass (FromJSON)
 
 -- | Breakdown of tokens used in the prompt
 data PromptTokensDetails = PromptTokensDetails
-    { prompt_audio_tokens :: Natural
+    { audio_tokens :: Natural
     , cached_tokens :: Natural
     } deriving stock (Generic, Show)
-
-instance FromJSON PromptTokensDetails where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "prompt_" }
+      deriving anyclass (FromJSON)
 
 -- | Usage statistics for the completion request
 data Usage = Usage
@@ -375,16 +324,13 @@ data ChatCompletion = ChatCompletion
     { id :: Text
     , choices :: Vector Choice
     , created :: POSIXTime
-    , response_model :: Text
-    , response_service_tier :: Maybe ServiceTier
+    , model :: Text
+    , service_tier :: Maybe ServiceTier
     , system_fingerprint :: Text
     , object :: Text
     , usage :: Usage
     } deriving stock (Generic, Show)
-
-instance FromJSON ChatCompletion where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "response_" }
+      deriving anyclass (FromJSON)
 
 -- | API
 type API =

--- a/src/OpenAI/Servant/V1/Embeddings.hs
+++ b/src/OpenAI/Servant/V1/Embeddings.hs
@@ -31,12 +31,9 @@ data CreateEmbeddings = CreateEmbeddings
 data Embedding = Embbedding
     { index :: Natural
     , embedding :: Vector Double
-    , embedding_object :: Text
+    , object :: Text
     } deriving stock (Generic, Show)
-
-instance FromJSON Embedding where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "embedding_" }
+      deriving anyclass (FromJSON)
 
 -- | API
 type API =

--- a/src/OpenAI/Servant/V1/Files.hs
+++ b/src/OpenAI/Servant/V1/Files.hs
@@ -46,12 +46,9 @@ data File = File
     , created_at :: POSIXTime
     , filename :: Text
     , object :: Text
-    , file_purpose :: Purpose
+    , purpose :: Purpose
     } deriving stock (Generic, Show)
-
-instance FromJSON File where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "file_" }
+      deriving anyclass (FromJSON)
 
 -- | The intended purpose of the uploaded file.
 data Purpose
@@ -90,13 +87,10 @@ instance ToHttpApiData Purpose where
 -- | Deletion status
 data Status = Status
     { status_id :: Text
-    , status_object :: Text
+    , object :: Text
     , deleted :: Bool
     } deriving stock (Generic, Show)
-
-instance FromJSON Status where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "status_" }
+      deriving anyclass (FromJSON)
 
 -- | API
 type API =

--- a/src/OpenAI/Servant/V1/FineTuning/Jobs.hs
+++ b/src/OpenAI/Servant/V1/FineTuning/Jobs.hs
@@ -101,24 +101,20 @@ data Job = Job
     , error :: Maybe Error
     , fine_tuned_model :: Maybe Text
     , finished_at :: Maybe POSIXTime
-    , job_hyperparameters :: Hyperparameters
-    , job_model :: Text
+    , hyperparameters :: Hyperparameters
+    , model :: Text
     , object :: Text
     , organization_id :: Text
     , result_files :: Vector Text
     , status :: Status
     , trained_tokens :: Maybe Natural
-    , job_training_file :: Text
-    , job_validation_file :: Maybe Text
-    , job_integrations :: Maybe (Vector Integration)
-    , job_seed :: Integer
+    , training_file :: Text
+    , validation_file :: Maybe Text
+    , integrations :: Maybe (Vector Integration)
+    , seed :: Integer
     , estimated_finish :: Maybe POSIXTime
-    }
-    deriving stock (Generic, Show)
-
-instance FromJSON Job where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "job_" }
+    } deriving stock (Generic, Show)
+      deriving anyclass (FromJSON)
 
 -- | Log level
 data Level = Info | Warn | Error
@@ -129,16 +125,13 @@ instance FromJSON Level where
 
 -- | Fine-tuning job event object
 data Event = Event
-    { event_id :: Text
-    , event_created_at :: POSIXTime
+    { id :: Text
+    , created_at :: POSIXTime
     , level :: Level
-    , event_message :: Text
-    , event_object :: Text
+    , message :: Text
+    , object :: Text
     } deriving stock (Generic, Show)
-
-instance FromJSON Event where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "event_" }
+      deriving anyclass (FromJSON)
 
 -- | Metrics at the step number during the fine-tuning job.
 data Metrics = Metrics
@@ -155,18 +148,15 @@ data Metrics = Metrics
 -- | The @fine_tuning.job.checkpoint@ object represents a model checkpoint for
 -- a fine-tuning job that is ready to use
 data Checkpoint = Checkpoint
-    { checkpoint_id :: Text
-    , checkpoint_created_at :: Text
+    { id :: Text
+    , created_at :: Text
     , fine_tuned_model_checkpoint :: Text
     , step_number :: Natural
     , metrics :: Metrics
     , fine_tuning_job_id :: Text
-    , checkpoint_object :: Text
+    , object :: Text
     } deriving stock (Generic, Show)
-
-instance FromJSON Checkpoint where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "checkpoint_" }
+      deriving anyclass (FromJSON)
 
 -- | API
 type API =

--- a/src/OpenAI/Servant/V1/Uploads.hs
+++ b/src/OpenAI/Servant/V1/Uploads.hs
@@ -71,12 +71,12 @@ instance FromJSON Status where
 data Upload file = Upload
     { id :: Text
     , created_at :: POSIXTime
-    , upload_filename :: Text
-    , upload_bytes :: Natural
-    , upload_purpose :: Purpose
+    , filename :: Text
+    , bytes :: Natural
+    , purpose :: Purpose
     , status :: Status
     , expires_at :: POSIXTime
-    , upload_object :: Text
+    , object :: Text
     , file :: file
     } deriving stock (Generic, Show)
 
@@ -87,26 +87,18 @@ data Upload file = Upload
 -- … is because that doesn't correctly handle the case where `file = Maybe b`.
 -- Specifically, it doesn't allow the field to be omitted even if the field
 -- can be `Nothing`.  However, adding a concrete instance avoids this issue.
-instance FromJSON (Upload (Maybe Void)) where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "upload_" }
-
-instance FromJSON (Upload File) where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "upload_" }
+instance FromJSON (Upload (Maybe Void))
+instance FromJSON (Upload File)
 
 -- | The upload `Part` represents a chunk of bytes we can add to an `Upload`
 -- object
 data Part = Part
-    { part_id :: Text
-    , part_created_at :: POSIXTime
+    { id :: Text
+    , created_at :: POSIXTime
     , upload_id :: Text
-    , part_object :: Text
+    , object :: Text
     } deriving stock (Generic, Show)
-
-instance FromJSON Part where
-    parseJSON = genericParseJSON aesonOptions
-        { fieldLabelModifier = stripPrefix "part_" }
+      deriving anyclass (FromJSON)
 
 -- | API
 type API

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -26,13 +26,12 @@ import OpenAI.Servant.V1.Chat.Completions
     , CreateChatCompletion(..)
     , Message(..)
     , Modality(..)
-    , ServiceTier(..)
     , Tool(..)
     , ToolCall(..)
     , ToolChoice(..)
     )
 import OpenAI.Servant.V1.FineTuning.Jobs
-    (AutoOr(..), CreateFineTuningJob(..), Hyperparameters(..), Job(..))
+    (CreateFineTuningJob(..), Hyperparameters(..), Job(..))
 import OpenAI.Servant.V1.Images.Generations
     (CreateImage(..), Quality(..), Style(..))
 import OpenAI.Servant.V1.Uploads
@@ -50,6 +49,7 @@ import qualified Network.HTTP.Client.TLS as TLS
 import qualified OpenAI.Servant.V1 as V1
 import qualified OpenAI.Servant.V1.Chat.Completions as Completions
 import qualified OpenAI.Servant.V1.Files as Files
+import qualified OpenAI.Servant.V1.FineTuning.Jobs as Jobs
 import qualified OpenAI.Servant.V1.Images.ResponseFormat as ResponseFormat
 import Prelude hiding (id)
 import qualified Servant.Client as Client
@@ -180,13 +180,11 @@ main = do
                                 , assistant_audio = Nothing
                                 , tool_calls = Just
                                     [ ToolCall_Function
-                                        { called_id =
-                                            "call_bzE95mjMMFqeanfY2sL6Sdir"
-                                        , called_function =
-                                            CalledFunction
-                                              { called_name = "hello"
-                                              , called_arguments = "{}"
-                                              }
+                                        { id = "call_bzE95mjMMFqeanfY2sL6Sdir"
+                                        , function = CalledFunction
+                                          { name = "hello"
+                                          , arguments = "{}"
+                                          }
                                         }
                                     ]
                                 }
@@ -210,20 +208,19 @@ main = do
                         , presence_penalty = Just 0
                         , response_format = Just Completions.ResponseFormat_Text
                         , seed = Just 0
-                        , service_tier = Just ServiceTier_Auto
+                        , service_tier = Just Completions.Auto
                         , stop = Just [ ">>>" ]
                         , temperature = Just 1
                         , top_p = Just 1
                         , tools = Just
                             [ Tool_Function
-                                { callable_function =
-                                    CallableFunction
-                                      { callable_description =
-                                          Just "Use the hello command line tool"
-                                      , callable_name = "hello"
-                                      , parameters = Nothing
-                                      , strict = Just False
-                                      }
+                                { function = CallableFunction
+                                  { description =
+                                      Just "Use the hello command line tool"
+                                  , name = "hello"
+                                  , parameters = Nothing
+                                  , strict = Just False
+                                  }
                                 }
                             ]
                         , tool_choice = Just ToolChoiceAuto
@@ -272,9 +269,9 @@ main = do
                         , training_file = trainingId
                         , hyperparameters = Just
                               Hyperparameters
-                                  { batch_size = Just Auto
-                                  , learning_rate_multiplier = Just Auto
-                                  , n_epochs = Just Auto
+                                  { batch_size = Just Jobs.Auto
+                                  , learning_rate_multiplier = Just Jobs.Auto
+                                  , n_epochs = Just Jobs.Auto
                                   }
                         , suffix = Just "haskell-openai"
                         , validation_file = Just validationId
@@ -339,10 +336,10 @@ main = do
                         , mime_type = "text/jsonl"
                         }
 
-                    Part{ part_id = partId0 } <- addUploadPart id AddUploadPart
+                    Part{ id = partId0 } <- addUploadPart id AddUploadPart
                         { data_ = "tasty/data/v1/uploads/training_data0.jsonl" }
 
-                    Part{ part_id = partId1 } <- addUploadPart id AddUploadPart
+                    Part{ id = partId1 } <- addUploadPart id AddUploadPart
                         { data_ = "tasty/data/v1/uploads/training_data1.jsonl" }
 
                     _ <- completeUpload id CompleteUpload


### PR DESCRIPTION
Now that we have unique datatype names we don't need prefixes to disambiguate colliding fields any longer