### PR TITLE
Simplify API further

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This provides a binding to OpenAI's API using `servant`
 Example usage:
 
 ```haskell
-{-# LANGUAGE BlockArguments        #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -13,58 +12,30 @@ Example usage:
 
 module Main where
 
-import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (traverse_)
-import Data.Text (Text)
-import Servant.Client (ClientM)
-import OpenAI.Servant.V1 (Methods(..))
-
+import OpenAI.Servant.V1
 import OpenAI.Servant.V1.Chat.Completions
 
-import qualified Control.Exception as Exception
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text.IO
-import qualified Network.HTTP.Client.TLS as TLS
-import qualified OpenAI.Servant.V1 as OpenAI
-import qualified Servant.Client as Client
 import qualified System.Environment as Environment
-
-contents :: Message -> Text
-contents System{ content } = content
-contents User{ content } = content
-contents Assistant{ assistant_content = Nothing } = ""
-contents Assistant{ assistant_content = Just content } = content
-contents Tool{ content } = content
 
 main :: IO ()
 main = do
-    manager <- TLS.newTlsManager
-
-    baseUrl <- Client.parseBaseUrl "https://api.openai.com"
-
-    let clientEnv = Client.mkClientEnv manager baseUrl
-
     key <- Environment.getEnv "OPENAI_KEY"
 
-    let Methods{ createChatCompletion } = OpenAI.getMethods (Text.pack key)
+    clientEnv <- getClientEnv "https://api.openai.com"
+
+    let Methods{ createChatCompletion } = makeMethods clientEnv (Text.pack key)
 
     line <- Text.IO.getLine
 
-    let run :: ClientM a -> IO a
-        run clientM = do
-            result <- Client.runClientM clientM clientEnv
+    ChatCompletion{ choices } <- createChatCompletion _CreateChatCompletion
+        { messages = [ User{ content = line, name = Nothing } ]
+        , model = "gpt-4o-mini"
+        }
 
-            case result of
-                Left clientError -> Exception.throwIO clientError
-                Right a -> return a
+    let display Choice{ message } = Text.IO.putStrLn (messageToContent message)
 
-    run do
-        ChatCompletion{ choices } <- createChatCompletion _CreateChatCompletion
-            { messages = [ User{ content = line, name = Nothing } ]
-            , model = "gpt-4o-mini"
-            }
-
-        let display Choice{ message } = Text.IO.putStrLn (contents message)
-
-        liftIO (traverse_ display choices)
+    traverse_ display choices
 ```

--- a/openai-servant-example/Main.hs
+++ b/openai-servant-example/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments        #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -6,56 +5,29 @@
 
 module Main where
 
-import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (traverse_)
-import Data.Text (Text)
-import Servant.Client (ClientM)
-import OpenAI.Servant.V1 (Methods(..))
+import OpenAI.Servant.V1
 import OpenAI.Servant.V1.Chat.Completions
 
-import qualified Control.Exception as Exception
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text.IO
-import qualified Network.HTTP.Client.TLS as TLS
-import qualified OpenAI.Servant.V1 as OpenAI
-import qualified Servant.Client as Client
 import qualified System.Environment as Environment
-
-contents :: Message -> Text
-contents System{ content } = content
-contents User{ content } = content
-contents Assistant{ assistant_content = Nothing } = ""
-contents Assistant{ assistant_content = Just content } = content
-contents Tool{ content } = content
 
 main :: IO ()
 main = do
-    manager <- TLS.newTlsManager
-
-    baseUrl <- Client.parseBaseUrl "https://api.openai.com"
-
-    let clientEnv = Client.mkClientEnv manager baseUrl
-
     key <- Environment.getEnv "OPENAI_KEY"
 
-    let Methods{ createChatCompletion } = OpenAI.getMethods (Text.pack key)
+    clientEnv <- getClientEnv "https://api.openai.com"
+
+    let Methods{ createChatCompletion } = makeMethods clientEnv (Text.pack key)
 
     line <- Text.IO.getLine
 
-    let run :: ClientM a -> IO a
-        run clientM = do
-            result <- Client.runClientM clientM clientEnv
+    ChatCompletion{ choices } <- createChatCompletion _CreateChatCompletion
+        { messages = [ User{ content = line, name = Nothing } ]
+        , model = "gpt-4o-mini"
+        }
 
-            case result of
-                Left clientError -> Exception.throwIO clientError
-                Right a -> return a
+    let display Choice{ message } = Text.IO.putStrLn (messageToContent message)
 
-    run do
-        ChatCompletion{ choices } <- createChatCompletion _CreateChatCompletion
-            { messages = [ User{ content = line, name = Nothing } ]
-            , model = "gpt-4o-mini"
-            }
-
-        let display Choice{ message } = Text.IO.putStrLn (contents message)
-
-        liftIO (traverse_ display choices)
+    traverse_ display choices

--- a/openai-servant.cabal
+++ b/openai-servant.cabal
@@ -20,6 +20,7 @@ library
                       , containers
                       , filepath
                       , http-api-data
+                      , http-client-tls
                       , servant
                       , servant-multipart-api
                       , servant-client
@@ -59,6 +60,7 @@ library
                       , OverloadedStrings
                       , RecordWildCards
                       , MultiParamTypeClasses
+                      , NamedFieldPuns
                       , TypeApplications
                       , TypeOperators
     ghc-options:        -Wall -Wno-missing-fields
@@ -85,7 +87,5 @@ executable openai-servant-example
     main-is:          Main.hs
     build-depends:    base
                     , openai-servant
-                    , http-client-tls
-                    , servant-client
                     , text
     ghc-options:      -Wall

--- a/src/OpenAI/Servant/V1/Chat/Completions.hs
+++ b/src/OpenAI/Servant/V1/Chat/Completions.hs
@@ -6,11 +6,13 @@ module OpenAI.Servant.V1.Chat.Completions
       CreateChatCompletion(..)
     , _CreateChatCompletion
     , ChatCompletion(..)
+    , Choice(..)
+    , Message(..)
+    , messageToContent
       -- * Other types
     , AudioData(..)
     , CalledFunction(..)
     , ToolCall(..)
-    , Message(..)
     , Modality(..)
     , Prediction(..)
     , Voice(..)
@@ -25,7 +27,6 @@ module OpenAI.Servant.V1.Chat.Completions
     , FinishReason(..)
     , Token(..)
     , LogProbs(..)
-    , Choice(..)
     , CompletionTokensDetails(..)
     , PromptTokensDetails(..)
     , Usage(..)
@@ -107,6 +108,21 @@ instance FromJSON Message where
 
 instance ToJSON Message where
     toJSON = genericToJSON messageOptions
+
+-- | Extract the message body from a `Message`
+--
+-- Normally this would just be the @content@ field selector, but the problem
+-- is that the content field for the `Assistant` constructor is not required
+-- to be present, so we provide a utility function to default to extract the
+-- @content@ field for all constructors, defaulting to @\"\"@ for the special
+-- case where the `Message` is an `Assistant` constructor with a missing
+-- @content@ field
+messageToContent :: Message -> Text
+messageToContent System{ content } = content
+messageToContent User{ content } = content
+messageToContent Assistant{ assistant_content = Just content } = content
+messageToContent Assistant{ assistant_content = Nothing } = ""
+messageToContent Tool{ content } = content
 
 -- | Output types that you would like the model to generate for this request
 data Modality = Text | Audio

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -10,7 +10,6 @@
 
 module Main where
 
-import Servant.Client (ClientM)
 import OpenAI.Servant.V1 (Methods(..))
 import OpenAI.Servant.V1.Audio.Transcriptions (CreateTranscription(..))
 import OpenAI.Servant.V1.Audio.Translations (CreateTranslation(..))
@@ -45,7 +44,6 @@ import OpenAI.Servant.V1.Uploads
     , Upload(..)
     )
 
-import qualified Control.Exception as Exception
 import qualified Data.Text as Text
 import qualified Network.HTTP.Client as HTTP.Client
 import qualified Network.HTTP.Client.TLS as TLS
@@ -78,29 +76,21 @@ main = do
     let user = "openai Haskell package"
     let chatModel = "gpt-4o-mini"
 
-    let Methods{..} = V1.getMethods (Text.pack key)
-
-    let run :: ClientM a -> IO a
-        run clientM = do
-            result <- Client.runClientM clientM clientEnv
-            case result of
-                Left clientError -> Exception.throwIO clientError
-                Right a -> return a
+    let Methods{..} = V1.makeMethods clientEnv (Text.pack key)
 
     -- Test each format to make sure we're handling each possible content type
     -- correctly
     let speechTest format =
             HUnit.testCase ("Create speech - " <> show format) do
-                run do
-                    _ <- createSpeech _CreateSpeech
-                        { model = "tts-1"
-                        , input = "Hello, world!"
-                        , voice = Nova
-                        , response_format = Just format
-                        , speed = Just 1.0
-                        }
+                _ <- createSpeech _CreateSpeech
+                    { model = "tts-1"
+                    , input = "Hello, world!"
+                    , voice = Nova
+                    , response_format = Just format
+                    , speed = Just 1.0
+                    }
 
-                    return ()
+                return ()
 
     let speechTests = do
             format <- [ minBound .. maxBound ]
@@ -108,349 +98,334 @@ main = do
 
     let transcriptionTest =
             HUnit.testCase "Create transcription" do
-                run do
-                    _ <- createTranscription CreateTranscription
-                        { file = "tasty/data/v1/audio/preamble.wav"
-                        , model = "whisper-1"
-                        , language = Just "en"
-                        , prompt = Nothing
-                        , temperature = Just 0
-                        }
+                _ <- createTranscription CreateTranscription
+                    { file = "tasty/data/v1/audio/preamble.wav"
+                    , model = "whisper-1"
+                    , language = Just "en"
+                    , prompt = Nothing
+                    , temperature = Just 0
+                    }
 
-                    return ()
+                return ()
 
     let translationTest =
             HUnit.testCase "Create translation" do
-                run do
-                    _ <- createTranslation CreateTranslation
-                        { file = "tasty/data/v1/audio/preamble.wav"
-                        , model = "whisper-1"
-                        , prompt = Nothing
-                        , temperature = Just 0
-                        }
+                _ <- createTranslation CreateTranslation
+                    { file = "tasty/data/v1/audio/preamble.wav"
+                    , model = "whisper-1"
+                    , prompt = Nothing
+                    , temperature = Just 0
+                    }
 
-                    return ()
+                return ()
 
     let completionsMinimalTest =
             HUnit.testCase "Create chat completion - minimal" do
-                run do
-                    _ <- createChatCompletion CreateChatCompletion
-                        { messages =
-                            [ User{ content = "Hello, world!", name = Nothing }
-                            ]
-                        , model = chatModel
-                        , store = Nothing
-                        , metadata = Nothing
-                        , frequency_penalty = Nothing
-                        , logit_bias = Nothing
-                        , logprobs = Nothing
-                        , top_logprobs = Nothing
-                        , max_completion_tokens = Nothing
-                        , n = Nothing
-                        , modalities = Nothing
-                        , prediction = Nothing
-                        , audio = Nothing
-                        , presence_penalty = Nothing
-                        , response_format = Nothing
-                        , seed = Nothing
-                        , service_tier = Nothing
-                        , stop = Nothing
-                        , temperature = Nothing
-                        , top_p = Nothing
-                        , tools = Nothing
-                        , tool_choice = Nothing
-                        , parallel_tool_calls = Nothing
-                        , user = Nothing
-                        }
+                _ <- createChatCompletion CreateChatCompletion
+                    { messages =
+                        [ User{ content = "Hello, world!", name = Nothing }
+                        ]
+                    , model = chatModel
+                    , store = Nothing
+                    , metadata = Nothing
+                    , frequency_penalty = Nothing
+                    , logit_bias = Nothing
+                    , logprobs = Nothing
+                    , top_logprobs = Nothing
+                    , max_completion_tokens = Nothing
+                    , n = Nothing
+                    , modalities = Nothing
+                    , prediction = Nothing
+                    , audio = Nothing
+                    , presence_penalty = Nothing
+                    , response_format = Nothing
+                    , seed = Nothing
+                    , service_tier = Nothing
+                    , stop = Nothing
+                    , temperature = Nothing
+                    , top_p = Nothing
+                    , tools = Nothing
+                    , tool_choice = Nothing
+                    , parallel_tool_calls = Nothing
+                    , user = Nothing
+                    }
 
-                    return ()
+                return ()
 
     let completionsMaximalTest =
             HUnit.testCase "Create chat completion - maximal" do
-                run do
-                    _ <- createChatCompletion CreateChatCompletion
-                        { messages =
-                            [ User
-                                { content = "Hello, world!"
-                                , name = Just "gabby"
-                                }
-                            , Assistant
-                                { assistant_content = Nothing
-                                , refusal = Nothing
-                                , name = Just "Ada"
-                                , assistant_audio = Nothing
-                                , tool_calls = Just
-                                    [ ToolCall_Function
-                                        { id = "call_bzE95mjMMFqeanfY2sL6Sdir"
-                                        , function = CalledFunction
-                                          { name = "hello"
-                                          , arguments = "{}"
-                                          }
-                                        }
-                                    ]
-                                }
-                            , Tool
-                                { content = "Hello, world!"
-                                , tool_call_id = "call_bzE95mjMMFqeanfY2sL6Sdir"
-                                }
-                            ]
-                        , model = chatModel
-                        , store = Just False
-                        , metadata = Nothing
-                        , frequency_penalty = Just 0
-                        , logit_bias = Just mempty
-                        , logprobs = Just True
-                        , top_logprobs = Just 1
-                        , max_completion_tokens = Just 1024
-                        , n = Just 1
-                        , modalities = Just [ Text ]
-                        , prediction = Nothing
-                        , audio = Nothing
-                        , presence_penalty = Just 0
-                        , response_format = Just Completions.ResponseFormat_Text
-                        , seed = Just 0
-                        , service_tier = Just Completions.Auto
-                        , stop = Just [ ">>>" ]
-                        , temperature = Just 1
-                        , top_p = Just 1
-                        , tools = Just
-                            [ Tool_Function
-                                { function = CallableFunction
-                                  { description =
-                                      Just "Use the hello command line tool"
-                                  , name = "hello"
-                                  , parameters = Nothing
-                                  , strict = Just False
-                                  }
-                                }
-                            ]
-                        , tool_choice = Just ToolChoiceAuto
-                        , parallel_tool_calls = Just True
-                        , user = Just user
-                        }
+                _ <- createChatCompletion CreateChatCompletion
+                    { messages =
+                        [ User
+                            { content = "Hello, world!"
+                            , name = Just "gabby"
+                            }
+                        , Assistant
+                            { assistant_content = Nothing
+                            , refusal = Nothing
+                            , name = Just "Ada"
+                            , assistant_audio = Nothing
+                            , tool_calls = Just
+                                [ ToolCall_Function
+                                    { id = "call_bzE95mjMMFqeanfY2sL6Sdir"
+                                    , function = CalledFunction
+                                      { name = "hello"
+                                      , arguments = "{}"
+                                      }
+                                    }
+                                ]
+                            }
+                        , Tool
+                            { content = "Hello, world!"
+                            , tool_call_id = "call_bzE95mjMMFqeanfY2sL6Sdir"
+                            }
+                        ]
+                    , model = chatModel
+                    , store = Just False
+                    , metadata = Nothing
+                    , frequency_penalty = Just 0
+                    , logit_bias = Just mempty
+                    , logprobs = Just True
+                    , top_logprobs = Just 1
+                    , max_completion_tokens = Just 1024
+                    , n = Just 1
+                    , modalities = Just [ Text ]
+                    , prediction = Nothing
+                    , audio = Nothing
+                    , presence_penalty = Just 0
+                    , response_format = Just Completions.ResponseFormat_Text
+                    , seed = Just 0
+                    , service_tier = Just Completions.Auto
+                    , stop = Just [ ">>>" ]
+                    , temperature = Just 1
+                    , top_p = Just 1
+                    , tools = Just
+                        [ Tool_Function
+                            { function = CallableFunction
+                              { description =
+                                  Just "Use the hello command line tool"
+                              , name = "hello"
+                              , parameters = Nothing
+                              , strict = Just False
+                              }
+                            }
+                        ]
+                    , tool_choice = Just ToolChoiceAuto
+                    , parallel_tool_calls = Just True
+                    , user = Just user
+                    }
 
-                    return ()
+                return ()
 
     let embeddingsTest = do
             HUnit.testCase "Create embedding" do
-                run do
-                    _ <- createEmbeddings CreateEmbeddings
-                        { input = "Hello, world!"
-                        , model = "text-embedding-3-small"
-                        , encoding_format = Just Float
-                        , dimensions = Just 1024
-                        , user = Just user
-                        }
+                _ <- createEmbeddings CreateEmbeddings
+                    { input = "Hello, world!"
+                    , model = "text-embedding-3-small"
+                    , encoding_format = Just Float
+                    , dimensions = Just 1024
+                    , user = Just user
+                    }
 
-                    return ()
+                return ()
 
     let fineTuningTest = do
             HUnit.testCase "Fine-tuning and File operations - maximal" do
-                run do
-                    File{ id = trainingId }<- uploadFile UploadFile
-                        { file =
-                            "tasty/data/v1/fine_tuning/jobs/training_data.jsonl"
-                        , purpose = Files.Fine_Tune
-                        }
+                File{ id = trainingId }<- uploadFile UploadFile
+                    { file =
+                        "tasty/data/v1/fine_tuning/jobs/training_data.jsonl"
+                    , purpose = Files.Fine_Tune
+                    }
 
-                    File{ id = validationId } <- uploadFile UploadFile
-                        { file =
-                            "tasty/data/v1/fine_tuning/jobs/validation_data.jsonl"
-                        , purpose = Files.Fine_Tune
-                        }
+                File{ id = validationId } <- uploadFile UploadFile
+                    { file =
+                        "tasty/data/v1/fine_tuning/jobs/validation_data.jsonl"
+                    , purpose = Files.Fine_Tune
+                    }
 
-                    _ <- retrieveFile trainingId
+                _ <- retrieveFile trainingId
 
-                    _ <- retrieveFileContent trainingId
+                _ <- retrieveFileContent trainingId
 
-                    _ <- listFiles (Just Files.Fine_Tune) (Just 10000) (Just Asc) Nothing
+                _ <- listFiles (Just Files.Fine_Tune) (Just 10000) (Just Asc) Nothing
 
-                    Job{ id } <- createFineTuningJob CreateFineTuningJob
-                        { model = "gpt-4o-mini-2024-07-18"
-                        , training_file = trainingId
-                        , hyperparameters = Just
-                              Hyperparameters
-                                  { batch_size = Just Jobs.Auto
-                                  , learning_rate_multiplier = Just Jobs.Auto
-                                  , n_epochs = Just Jobs.Auto
-                                  }
-                        , suffix = Just "haskell-openai"
-                        , validation_file = Just validationId
-                        , integrations = Just []
-                        , seed = Just 0
-                        }
+                Job{ id } <- createFineTuningJob CreateFineTuningJob
+                    { model = "gpt-4o-mini-2024-07-18"
+                    , training_file = trainingId
+                    , hyperparameters = Just
+                          Hyperparameters
+                              { batch_size = Just Jobs.Auto
+                              , learning_rate_multiplier = Just Jobs.Auto
+                              , n_epochs = Just Jobs.Auto
+                              }
+                    , suffix = Just "haskell-openai"
+                    , validation_file = Just validationId
+                    , integrations = Just []
+                    , seed = Just 0
+                    }
 
-                    _ <- retrieveFineTuningJob id
+                _ <- retrieveFineTuningJob id
 
-                    _ <- listFineTuningJobs Nothing (Just 20)
+                _ <- listFineTuningJobs Nothing (Just 20)
 
-                    _ <- listFineTuningCheckpoints id Nothing (Just 10)
+                _ <- listFineTuningCheckpoints id Nothing (Just 10)
 
-                    _ <- cancelFineTuning id
+                _ <- cancelFineTuning id
 
-                    _ <- listFineTuningEvents id Nothing (Just 20)
+                _ <- listFineTuningEvents id Nothing (Just 20)
 
-                    _ <- deleteFile trainingId
-                    _ <- deleteFile validationId
+                _ <- deleteFile trainingId
+                _ <- deleteFile validationId
 
-                    return ()
+                return ()
 
     let batchesTest = do
             HUnit.testCase "Batch operations" do
-                run do
-                    File{ id = requestsId } <- uploadFile UploadFile
-                        { file = "tasty/data/v1/batches/requests.jsonl"
-                        , purpose = Files.Batch
-                        }
+                File{ id = requestsId } <- uploadFile UploadFile
+                    { file = "tasty/data/v1/batches/requests.jsonl"
+                    , purpose = Files.Batch
+                    }
 
-                    Batch{ id } <- createBatch CreateBatch
-                        { input_file_id = requestsId
-                        , endpoint = "/v1/chat/completions"
-                        , completion_window = "24h"
-                        , metadata = Nothing
-                        }
+                Batch{ id } <- createBatch CreateBatch
+                    { input_file_id = requestsId
+                    , endpoint = "/v1/chat/completions"
+                    , completion_window = "24h"
+                    , metadata = Nothing
+                    }
 
-                    _ <- retrieveBatch id
+                _ <- retrieveBatch id
 
-                    _ <- listBatch Nothing (Just 20)
+                _ <- listBatch Nothing (Just 20)
 
-                    _ <- cancelBatch id
+                _ <- cancelBatch id
 
-                    return ()
+                return ()
 
     let uploadsTest = do
             HUnit.testCase "Upload operations" do
-                run do
-                    Upload{ id = cancelledId } <- createUpload CreateUpload
-                        { filename = "training_data.jsonl"
-                        , purpose = Files.Fine_Tune
-                        , bytes = 4077
-                        , mime_type = "text/jsonl"
-                        }
+                Upload{ id = cancelledId } <- createUpload CreateUpload
+                    { filename = "training_data.jsonl"
+                    , purpose = Files.Fine_Tune
+                    , bytes = 4077
+                    , mime_type = "text/jsonl"
+                    }
 
-                    _ <- cancelUpload cancelledId
+                _ <- cancelUpload cancelledId
 
-                    Upload{ id } <- createUpload CreateUpload
-                        { filename = "training_data.jsonl"
-                        , purpose = Files.Fine_Tune
-                        , bytes = 4077
-                        , mime_type = "text/jsonl"
-                        }
+                Upload{ id } <- createUpload CreateUpload
+                    { filename = "training_data.jsonl"
+                    , purpose = Files.Fine_Tune
+                    , bytes = 4077
+                    , mime_type = "text/jsonl"
+                    }
 
-                    Part{ id = partId0 } <- addUploadPart id AddUploadPart
-                        { data_ = "tasty/data/v1/uploads/training_data0.jsonl" }
+                Part{ id = partId0 } <- addUploadPart id AddUploadPart
+                    { data_ = "tasty/data/v1/uploads/training_data0.jsonl" }
 
-                    Part{ id = partId1 } <- addUploadPart id AddUploadPart
-                        { data_ = "tasty/data/v1/uploads/training_data1.jsonl" }
+                Part{ id = partId1 } <- addUploadPart id AddUploadPart
+                    { data_ = "tasty/data/v1/uploads/training_data1.jsonl" }
 
-                    _ <- completeUpload id CompleteUpload
-                        { part_ids = [ partId0, partId1 ]
-                        , md5 = Nothing
-                        }
+                _ <- completeUpload id CompleteUpload
+                    { part_ids = [ partId0, partId1 ]
+                    , md5 = Nothing
+                    }
 
-                    return ()
+                return ()
 
     let createImageMinimalTest = do
             HUnit.testCase "Create image - minimal" do
-                run do
-                    _ <- createImage CreateImage
-                        { prompt = "A baby panda"
-                        , model = Nothing
-                        , n = Nothing
-                        , quality = Nothing
-                        , response_format = Nothing
-                        , size = Nothing
-                        , style = Nothing
-                        , user = Nothing
-                        }
+                _ <- createImage CreateImage
+                    { prompt = "A baby panda"
+                    , model = Nothing
+                    , n = Nothing
+                    , quality = Nothing
+                    , response_format = Nothing
+                    , size = Nothing
+                    , style = Nothing
+                    , user = Nothing
+                    }
 
-                    return ()
+                return ()
 
     let createImageMaximalTest = do
             HUnit.testCase "Create image - maximal" do
-                run do
-                    _ <- createImage CreateImage
-                        { prompt = "A baby panda"
-                        , model = Just "dall-e-2"
-                        , n = Just 1
-                        , quality = Just Standard
-                        , response_format = Just ResponseFormat.URL
-                        , size = Just "1024x1024"
-                        , style = Just Vivid
-                        , user = Just user
-                        }
+                _ <- createImage CreateImage
+                    { prompt = "A baby panda"
+                    , model = Just "dall-e-2"
+                    , n = Just 1
+                    , quality = Just Standard
+                    , response_format = Just ResponseFormat.URL
+                    , size = Just "1024x1024"
+                    , style = Just Vivid
+                    , user = Just user
+                    }
 
-                    return ()
+                return ()
 
     let createImageEditMinimalTest = do
             HUnit.testCase "Create image edit - minimal" do
-                run do
-                    _ <- createImageEdit CreateImageEdit
-                        { image = "tasty/data/v1/images/image.png"
-                        , prompt = "The panda should be greener"
-                        , mask = Nothing
-                        , model = Nothing
-                        , n = Nothing
-                        , size = Nothing
-                        , response_format = Nothing
-                        , user = Nothing
-                        }
+                _ <- createImageEdit CreateImageEdit
+                    { image = "tasty/data/v1/images/image.png"
+                    , prompt = "The panda should be greener"
+                    , mask = Nothing
+                    , model = Nothing
+                    , n = Nothing
+                    , size = Nothing
+                    , response_format = Nothing
+                    , user = Nothing
+                    }
 
-                    return ()
+                return ()
 
     let createImageEditMaximalTest = do
             HUnit.testCase "Create image edit - maximal" do
-                run do
-                    _ <- createImageEdit CreateImageEdit
-                        { image = "tasty/data/v1/images/image.png"
-                        , prompt = "The panda should be greener"
-                        , mask = Nothing
-                        , model = Just "dall-e-2"
-                        , n = Just 1
-                        , size = Just "1024x1024"
-                        , response_format = Just ResponseFormat.URL
-                        , user = Just user
-                        }
+                _ <- createImageEdit CreateImageEdit
+                    { image = "tasty/data/v1/images/image.png"
+                    , prompt = "The panda should be greener"
+                    , mask = Nothing
+                    , model = Just "dall-e-2"
+                    , n = Just 1
+                    , size = Just "1024x1024"
+                    , response_format = Just ResponseFormat.URL
+                    , user = Just user
+                    }
 
-                    return ()
+                return ()
 
     let createImageVariationMinimalTest = do
             HUnit.testCase "Create image variation - minimal" do
-                run do
-                    _ <- createImageVariation CreateImageVariation
-                        { image = "tasty/data/v1/images/image.png"
-                        , model = Nothing
-                        , n = Nothing
-                        , response_format = Nothing
-                        , size = Nothing
-                        , user = Nothing
-                        }
+                _ <- createImageVariation CreateImageVariation
+                    { image = "tasty/data/v1/images/image.png"
+                    , model = Nothing
+                    , n = Nothing
+                    , response_format = Nothing
+                    , size = Nothing
+                    , user = Nothing
+                    }
 
-                    return ()
+                return ()
 
     let createImageVariationMaximalTest = do
             HUnit.testCase "Create image variation - maximal" do
-                run do
-                    _ <- createImageVariation CreateImageVariation
-                        { image = "tasty/data/v1/images/image.png"
-                        , model = Just "dall-e-2"
-                        , n = Just 1
-                        , response_format = Just ResponseFormat.URL
-                        , size = Just "1024x1024"
-                        , user = Just user
-                        }
+                _ <- createImageVariation CreateImageVariation
+                    { image = "tasty/data/v1/images/image.png"
+                    , model = Just "dall-e-2"
+                    , n = Just 1
+                    , response_format = Just ResponseFormat.URL
+                    , size = Just "1024x1024"
+                    , user = Just user
+                    }
 
-                    return ()
+                return ()
 
     let createModerationTest = do
             HUnit.testCase "Create moderation" do
-                run do
-                    _ <- createModeration CreateModeration
-                        { input = "I am going to kill you"
-                        , model = Nothing
-                        }
+                _ <- createModeration CreateModeration
+                    { input = "I am going to kill you"
+                    , model = Nothing
+                    }
 
-                    return ()
+                return ()
 
     let tests =
                 speechTests


### PR DESCRIPTION
In particular, change the API to expose ordinary `IO` instead of `ClientEnv`, but this also includes other small touches to make it so that most users don't need to depend on `servant-client` or `http-client-tls` to get going