### PR TITLE
Add 'minimal' option to ReasoningEffort enum

### DIFF
--- a/src/OpenAI/V1/Chat/Completions.hs
+++ b/src/OpenAI/V1/Chat/Completions.hs
@@ -221,7 +221,8 @@ instance ToJSON ServiceTier where
 
 -- | Constrains effort on reasoning for reasoning models
 data ReasoningEffort
-    = ReasoningEffort_Low
+    = ReasoningEffort_Minimal
+    | ReasoningEffort_Low
     | ReasoningEffort_Medium
     | ReasoningEffort_High
     deriving stock (Generic, Show)


### PR DESCRIPTION
- Added `ReasoningEffort_Minimal` to the `ReasoningEffort` enum to support the new 'minimal' effort level for reasoning models (https://platform.openai.com/docs/api-reference/chat/create#chat_create-reasoning_effort)