### PR TITLE
Add ReasoningEffort_None (serializes as "none")

### DIFF
--- a/src/OpenAI/V1/Chat/Completions.hs
+++ b/src/OpenAI/V1/Chat/Completions.hs
@@ -216,7 +216,8 @@ type ServiceTier = Text
 
 -- | Constrains effort on reasoning for reasoning models
 data ReasoningEffort
-    = ReasoningEffort_Minimal
+    = ReasoningEffort_None
+    | ReasoningEffort_Minimal
     | ReasoningEffort_Low
     | ReasoningEffort_Medium
     | ReasoningEffort_High


### PR DESCRIPTION
The new models like OpenAI Luna require reasoning effort be set to none for function calling.